### PR TITLE
Rework command line argument parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Demo:
 
 ### VS Code
 You can also edit encrypted files directly in VS Code, without password prompt or having to decrypt them first.  
-This limits the risk of accidentaly commiting secrets in plain text to source control.
+This limits the risk of accidentally commiting secrets in plain text to source control.
 
 In the integrated terminal , run...  
 ```bash

--- a/ansible-vault-bw.sh
+++ b/ansible-vault-bw.sh
@@ -3,15 +3,68 @@
 # Use a session token to unlock your Bitwarden Vault shell-wide.
 # export BW_SESSION=$(bw unlock | grep -oP 'BW_SESSION="\K[^"]+' | head -n 1)
 
+# Bitwarden entry name precedence:
+# 1. Command line argument BW_PASS_NAME
+# 2. Environment variable BW_PASS_NAME
+# 3. Default value BW_DEFAULT_PASS_ENTRY
+
+# Default value for command line argument should be empty
+BW_PASS_NAME_CLI=""
+
 # Default Bitwarden secret
 BW_DEFAULT_PASS_ENTRY="ansible-vault-main"
 
-# Check if a variable for the Bitwarden secret was provided via environment
+# Begin parsing command line arguments
+print_usage() {
+  echo "Usage: $0 [-e, --bw-entry BW_PASS_NAME]"
+}
+
+# Use getopt to parse the options
+PARSED=$(getopt --options he: --long help,bw-entry: --name "$0" -- "$@")
+if [[ $? -ne 0 ]]; then
+  # getopt has complained about wrong arguments
+  exit 2
+fi
+
+# Evaluate the parsed options
+eval set -- "$PARSED"
+
+# Process options
+while true; do
+  case "$1" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    -e|--bw-entry)
+      BW_PASS_NAME_CLI="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Unexpected option: $1" >&2
+      exit 3
+      ;;
+  esac
+done
+# End parsing command line arguments
+
+# Check if a variable for the Bitwarden secret was provided via cli or environment variable
 check_env_var(){
+    # Set default Bitwarden entry
+    BW_PASS_ENTRY="$BW_DEFAULT_PASS_ENTRY"
+
+    # If the environment variable is set, use that
     if [ -n "$BW_PASS_NAME" ]; then
-        BW_PASS_ENTRY="$BW_PASS_NAME"
-    else
-        BW_PASS_ENTRY="$BW_DEFAULT_PASS_ENTRY"
+      BW_PASS_ENTRY="$BW_PASS_NAME"
+    fi
+
+    # If we have a command line argument, use that instead
+    if [ -n "$BW_PASS_NAME_CLI" ]; then
+      BW_PASS_ENTRY="$BW_PASS_NAME_CLI"
     fi
 }
 
@@ -20,7 +73,7 @@ bw_status_parsing() {
     bw_status=$(bw status --session="$BW_SESSION" | jq -r '.status')
 }
 
-# Check Bitwarden Vault status locked/unlocked and echo $BW_DEFAULT_PASS_ENTRY
+# Check Bitwarden Vault status locked/unlocked and echo the password
 bw_status_check_default() {
     if [ "$bw_status" = "locked" ]; then
         exit
@@ -32,6 +85,6 @@ bw_status_check_default() {
 }
 
 # Run
-check_env_var "$1"  # Pass the first argument to the function
+check_env_var
 bw_status_parsing
 bw_status_check_default


### PR DESCRIPTION
I couldn't actually see where your command line argument "--bw-entry" was being parsed. It seemed to rely on not using a named argument. If that is how you prefer then perhaps ignore this and just update the Readme. But I like named arguments so I have made it work here. Feel free to merge if you like that too!

Thanks for working on this, I had a similar script but only half done. This is much better!